### PR TITLE
First abs build (not defaults)

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,7 @@
+aggregate_check: false
+upload_channels:
+  - sfe1ed40
+  - services
+channels:
+  - sfe1ed40
+  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,6 @@
 {% set name = "opentelemetry-sdk" %}
 {% set version = "1.12.0" %}
+{% set sha256 = "bf37830ca4f93d0910cf109749237c5cb4465e31a54dfad8400011e9822a2a14" %}
 
 package:
   name: {{ name|lower }}
@@ -7,29 +8,24 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: bf37830ca4f93d0910cf109749237c5cb4465e31a54dfad8400011e9822a2a14
+  sha256: {{ sha256 }}
 
 build:
   number: 0
-  noarch: python
+  # noarch: python
+  skip: true  # [py<36]
   script: {{ PYTHON }} -m pip install . -vv
 
 requirements:
   host:
     - pip
-    - python >=3.6
+    - python
   run:
+    - python
     - opentelemetry-api ==1.12.0
-    - python >=3.6
     - opentelemetry-semantic-conventions ==0.33b0
     - typing_extensions >=3.7.4
-    # - setuptools >=16.0
-    - dataclasses ==0.8
-    # - setuptools >=16.0
-    # - setuptools >=16.0
-    # - setuptools >=16.0
-    # - setuptools >=16.0
-    # - setuptools >=16.0
+    - dataclasses ==0.8  # [py<37]
 
 test:
   imports:
@@ -41,10 +37,18 @@ test:
     - pip
 
 about:
-  home: https://github.com/open-telemetry/opentelemetry-python/tree/measter/opentelemetry-sdk
+  home: https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-sdk
   summary: OpenTelemetry Python SDK
   license: Apache-2.0
+  license_family: Apache
   license_file: LICENSE
+  summary: OpenTelemetry Python SDK
+  doc_url: https://opentelemetry.io
+  description: |-
+    OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
+    Observability framework for instrumenting, generating, collecting, and exporting
+    telemetry data such as traces, metrics, logs. As an industry-standard
+    it is natively supported by a number of vendors.
 
 extra:
   recipe-maintainers:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -14,12 +14,14 @@ build:
   number: 0
   # noarch: python
   skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . -vv
+  script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
   host:
     - pip
     - python
+    - setuptools
+    - wheel
   run:
     - python
     - opentelemetry-api ==1.12.0
@@ -37,13 +39,13 @@ test:
     - pip
 
 about:
+  summary: OpenTelemetry Python / SDK
   home: https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-sdk
-  summary: OpenTelemetry Python SDK
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  summary: OpenTelemetry Python SDK
-  doc_url: https://opentelemetry.io
+  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting


### PR DESCRIPTION
Note: this is currently not a defaults channel package.

- Removed python pins, replaced with skip
- Removed noarch
- Added selector for dataclasses dep
- Added metadata