### PR TITLE
[PKG-4251] 1.23.0 ❄️ 

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,7 +1,2 @@
-aggregate_check: false
 upload_channels:
   - sfe1ed40
-  - services
-channels:
-  - sfe1ed40
-  - services

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,9 +12,8 @@ source:
 
 build:
   number: 0
-  # noarch: python
-  skip: true  # [py<36]
-  script: {{ PYTHON }} -m pip install . --no-deps -vv
+  skip: true  # [py<38]
+  script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
   host:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ about:
   license: Apache-2.0
   license_family: Apache
   license_file: LICENSE
-  doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
+  doc_url: https://opentelemetry-python.readthedocs.io
   dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-sdk
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -22,10 +22,9 @@ requirements:
     - hatchling
   run:
     - python
-    - opentelemetry-api ==1.12.0
-    - opentelemetry-semantic-conventions ==0.33b0
+    - opentelemetry-api ==1.23.0
+    - opentelemetry-semantic-conventions ==0.44b0
     - typing_extensions >=3.7.4
-    - dataclasses ==0.8  # [py<37]
 
 test:
   imports:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,7 +7,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_sdk-{{ version }}.tar.gz
   sha256: {{ sha256 }}
 
 build:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -42,7 +42,7 @@ about:
   license_family: Apache
   license_file: LICENSE
   doc_url: https://opentelemetry-python.readthedocs.io/en/latest/
-  doc_source_url: https://github.com/open-telemetry/opentelemetry-python/tree/main/docs
+  dev_url: https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-sdk
   description: |-
     OpenTelemetry, also known as OTel for short, is a vendor-neutral open-source
     Observability framework for instrumenting, generating, collecting, and exporting

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "opentelemetry-sdk" %}
-{% set version = "1.12.0" %}
-{% set sha256 = "bf37830ca4f93d0910cf109749237c5cb4465e31a54dfad8400011e9822a2a14" %}
+{% set version = "1.23.0" %}
+{% set sha256 = "9ddf60195837b59e72fd2033d6a47e2b59a0f74f0ec37d89387d89e3da8cab7f" %}
 
 package:
   name: {{ name|lower }}

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,8 +19,7 @@ requirements:
   host:
     - pip
     - python
-    - setuptools
-    - wheel
+    - hatchling
   run:
     - python
     - opentelemetry-api ==1.12.0


### PR DESCRIPTION
opentelemetry-sdk 1.23.0 :snowflake:

**Destination channel:** Snowflake

### Links

- [PKG-4251]
- [Upstream repository](https://github.com/open-telemetry/opentelemetry-python/tree/master/opentelemetry-sdk)
- Upstream [changelog](https://github.com/open-telemetry/opentelemetry-python/releases/tag/v1.23.0) / [diff](https://github.com/open-telemetry/opentelemetry-python/compare/v1.15.0...v1.23.0)
- Relevant dependency PRs:
  - https://github.com/AnacondaRecipes/opentelemetry-api-feedstock/pull/2
  - https://github.com/AnacondaRecipes/opentelemetry-semantic-conventions-feedstock/pull/3

### Explanation of changes:

- Unable to run upstream tests as they require the `opentelemetry.test` module from the top level package and several missing dependencies.


[PKG-4251]: https://anaconda.atlassian.net/browse/PKG-4251?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ