### PR TITLE
Version 1.2.6

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,2 +1,0 @@
-upload_channels:
-  - sfe1ed40

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,5 @@
 {% set name = "opentelemetry-sdk" %}
-{% set version = "1.23.0" %}
-{% set sha256 = "9ddf60195837b59e72fd2033d6a47e2b59a0f74f0ec37d89387d89e3da8cab7f" %}
+{% set version = "1.26.0" %}
 
 package:
   name: {{ name|lower }}
@@ -8,7 +7,10 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/opentelemetry_sdk-{{ version }}.tar.gz
-  sha256: {{ sha256 }}
+  sha256: c90d2868f8805619535c05562d699e2f4fb1f00dbd55a86dcefca4da6fa02f85
+  patches:
+    # added to avoid pip._internal.exceptions.MetadataGenerationFailed: metadata generation failed
+    - patches/0000-fix-classifier-clash-in-pyproject.patch
 
 build:
   number: 0
@@ -16,14 +18,17 @@ build:
   script: {{ PYTHON }} -m pip install . --no-deps --no-build-isolation -vv
 
 requirements:
+  build:
+    - patch # [not win]
+    - m2-patch  # [win]
   host:
     - pip
     - python
     - hatchling
   run:
     - python
-    - opentelemetry-api ==1.23.0
-    - opentelemetry-semantic-conventions ==0.44b0
+    - opentelemetry-api ==1.26.0
+    - opentelemetry-semantic-conventions ==0.47b0
     - typing_extensions >=3.7.4
 
 test:

--- a/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
+++ b/recipe/patches/0000-fix-classifier-clash-in-pyproject.patch
@@ -1,0 +1,10 @@
+--- pyproject.toml	2024-08-27 12:14:39.355588362 +0100
++++ "pyproject copy.toml"	2024-08-29 13:37:46.743119994 +0100
+@@ -14,7 +14,6 @@
+ ]
+ classifiers = [
+   "Development Status :: 5 - Production/Stable",
+-  "Framework :: OpenTelemetry",
+   "Intended Audience :: Developers",
+   "License :: OSI Approved :: Apache Software License",
+   "Programming Language :: Python",


### PR DESCRIPTION
opentelemetry-sdk 1.26

**Destination channel:** defaults

### Explanation of changes:

- add patch for metadata generation
- version and sha 
